### PR TITLE
Typo in variable definition

### DIFF
--- a/vpc_external_subnet/main.tf
+++ b/vpc_external_subnet/main.tf
@@ -1,4 +1,4 @@
-ariable "name" {
+variable "name" {
   description = "Name to give the route table"
 }
 


### PR DESCRIPTION
Fix definition of variable for external subnet name