### PR TITLE
Ensure unique name for nat instance security group

### DIFF
--- a/nat_instance/main.tf
+++ b/nat_instance/main.tf
@@ -49,7 +49,7 @@ data "aws_ami" "nat_ami" {
 }
 
 resource "aws_security_group" "nat_instance" {
-  name        = "nat"
+  name        = "nat-${var.name}"
   description = "Allow traffic from clients into NAT instances"
 
   ingress {


### PR DESCRIPTION
NAT instance security group name is currently not unique, adds name to the end of it to ensure it is partly unique.