### PR TITLE
Allow specifying tags for internal and external subnets

### DIFF
--- a/vpc_external_subnet/main.tf
+++ b/vpc_external_subnet/main.tf
@@ -22,6 +22,11 @@ variable "map_public_ip_on_launch" {
   default = true
 }
 
+variable "subnet_tags" {
+  default = {}
+  type    = "map"
+}
+
 variable "route_table_id" {
   description = "The ID route table to associate the subnet table with"
 }
@@ -32,11 +37,7 @@ resource "aws_subnet" "external" {
   availability_zone       = "${var.subnet_az}"
   map_public_ip_on_launch = "${var.map_public_ip_on_launch}"
 
-  tags {
-    Name        = "${var.name}"
-    Environment = "${var.environment}"
-    terraform   = "true"
-  }
+  tags = "${merge(map("Name", format("%s", var.name), "Environment", format("%s", var.environment), "terraform", "true"), var.subnet_tags)}"
 }
 
 resource "aws_route_table_association" "external" {

--- a/vpc_internal_subnet/main.tf
+++ b/vpc_internal_subnet/main.tf
@@ -22,16 +22,17 @@ variable "route_table_id" {
   description = "The ID route table to associate the subnet table with"
 }
 
+variable "subnet_tags" {
+  default = {}
+  type    = "map"
+}
+
 resource "aws_subnet" "internal" {
   vpc_id            = "${var.vpc_id}"
   cidr_block        = "${var.subnet_cidr}"
   availability_zone = "${var.subnet_az}"
 
-  tags {
-    Name        = "${var.name}"
-    Environment = "${var.environment}"
-    terraform   = "true"
-  }
+  tags = "${merge(map("Name", format("%s", var.name), "Environment", format("%s", var.environment), "terraform", "true"), var.subnet_tags)}"
 }
 
 resource "aws_route_table_association" "internal" {


### PR DESCRIPTION
This allows merging in a map of tags to add to the internal and external subnets. Primary use case for this is adding tags to subnets that are then used with kops which requires specific tags on the subnet.